### PR TITLE
Fix small error in Ipfp-doc's examples

### DIFF
--- a/mipfp/man/Ipfp.Rd
+++ b/mipfp/man/Ipfp.Rd
@@ -137,7 +137,7 @@ seed.2d <- array(1,dim=c(2,2))
 target.row <- c(50,50)
 target.col <- c(30,70)
 # storing the margins in a list
-tgt.data.2d <- list(target.col, target.row)
+tgt.data.2d <- list(target.row, target.col)
 # list of dimensions of each marginal constraint
 tgt.list.2d <- list(1,2)
 # calling the Ipfp function


### PR DESCRIPTION
Apparently the margin-list was specified in the wrong order, which confused me a bit.
The example reads:
```
seed.2d <- array(1,dim=c(2,2))
# desired targets (margins) : V1 and V2
target.row <- c(50,50)
target.col <- c(30,70)
# storing the margins in a list
tgt.data.2d <- list(target.col, target.row) # NOTE
# list of dimensions of each marginal constrain
tgt.list.2d <- list(1,2)
# calling the Ipfp function
res.2d <- Ipfp(seed.2d, tgt.list.2d, tgt.data.2d)
```
This results in the following estimates:
```
Estimates:
     [,1] [,2]
[1,]   15   15
[2,]   35   35
```
That is, the rows sum to 30 and 70 instead of 50 and 50. I fixed it by switching the objects position in the list.